### PR TITLE
[Bugfix] 일정·할일 전환 시 입력 상태와 미리보기 동기화 오류 수정

### DIFF
--- a/src/features/Calendar/components/CustomCalendar/CalendarModals.tsx
+++ b/src/features/Calendar/components/CustomCalendar/CalendarModals.tsx
@@ -1,8 +1,11 @@
 import moment from 'moment'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useDetailEventQuery } from '@/shared/hooks/query/useCalendarQueries'
 import type { CalendarEvent } from '@/shared/types/calendar/types'
+import type { RepeatConfigSchema } from '@/shared/types/event/event'
+import type { ItemEditorDraft } from '@/shared/types/modal/itemEditor'
+import { defaultRepeatConfig } from '@/shared/types/recurrence/repeat'
 import ScheduleEditorModal from '@/shared/ui/Modals/ScheduleEditor'
 import TodoEditorModal from '@/shared/ui/Modals/TodoEditor'
 
@@ -25,6 +28,107 @@ type CalendarModalsProps = {
       occurrenceDate?: CalendarEvent['occurrenceDate'],
     ) => void
   }
+}
+
+const pad2 = (value: number) => String(value).padStart(2, '0')
+
+const formatTimeFromDate = (value: Date) => `${pad2(value.getHours())}:${pad2(value.getMinutes())}`
+
+const getDefaultDraft = (
+  date: string,
+  initialType: 'todo' | 'schedule',
+  initialEvent?: CalendarEvent | null,
+): ItemEditorDraft => {
+  const baseStart = initialEvent?.start ? new Date(initialEvent.start) : new Date(date)
+  const baseEnd =
+    initialEvent?.end && new Date(initialEvent.end).getTime() !== baseStart.getTime()
+      ? new Date(initialEvent.end)
+      : new Date(baseStart.getTime() + 60 * 60 * 1000)
+
+  return {
+    title:
+      initialType === 'schedule' && initialEvent?.title === '새 일정'
+        ? ''
+        : (initialEvent?.title ?? ''),
+    description: initialEvent?.content ?? '',
+    startDate: baseStart,
+    endDate: baseEnd,
+    startTime: formatTimeFromDate(baseStart),
+    endTime: initialType === 'todo' ? formatTimeFromDate(baseStart) : formatTimeFromDate(baseEnd),
+    isAllday: initialEvent?.isAllDay ?? false,
+    eventColor: initialEvent?.color ?? (initialType === 'todo' ? 'GRAY' : 'BLUE'),
+    repeatConfig: defaultRepeatConfig as RepeatConfigSchema,
+    location: initialEvent?.location ?? '',
+    address: initialEvent?.address ?? null,
+  }
+}
+
+type DraftBackedModalProps = {
+  modalDate: string
+  modalEventId: CalendarEvent['id']
+  modalEvent: CalendarEvent | null
+  detailEvent: CalendarEvent | null
+  isModalEditing: boolean
+  modalMode: 'modal' | 'inline'
+  onCloseModal: () => void
+  eventActions: CalendarModalsProps['eventActions']
+}
+
+const DraftBackedModal = ({
+  modalDate,
+  modalEventId,
+  modalEvent,
+  detailEvent,
+  isModalEditing,
+  modalMode,
+  onCloseModal,
+  eventActions,
+}: DraftBackedModalProps) => {
+  const isTodoModal = modalEvent?.type === 'todo'
+  const activeEvent = detailEvent ?? modalEvent
+  const [draftValues, setDraftValues] = useState<ItemEditorDraft | null>(() =>
+    isModalEditing
+      ? null
+      : getDefaultDraft(modalDate, isTodoModal ? 'todo' : 'schedule', activeEvent),
+  )
+
+  if (isTodoModal) {
+    return (
+      <TodoEditorModal
+        date={modalDate}
+        onClose={onCloseModal}
+        mode={modalMode}
+        eventId={modalEventId}
+        event={modalEvent}
+        showTypeTabs={!isModalEditing}
+        draftValues={draftValues}
+        onDraftChange={setDraftValues}
+        onEventColorChange={eventActions.onEventColorChange}
+        onEventTitleConfirm={eventActions.onEventTitleConfirm}
+        onEventTypeChange={eventActions.onEventTypeChange}
+        onEventTimingChange={eventActions.onEventTimingChange}
+        isEditing={isModalEditing}
+      />
+    )
+  }
+
+  return (
+    <ScheduleEditorModal
+      date={modalDate}
+      onClose={onCloseModal}
+      mode={modalMode}
+      eventId={modalEventId}
+      event={detailEvent ?? modalEvent}
+      isEditing={isModalEditing}
+      showTypeTabs={!isModalEditing}
+      draftValues={draftValues}
+      onDraftChange={setDraftValues}
+      onEventColorChange={eventActions.onEventColorChange}
+      onEventTitleConfirm={eventActions.onEventTitleConfirm}
+      onEventTypeChange={eventActions.onEventTypeChange}
+      onEventTimingChange={eventActions.onEventTimingChange}
+    />
+  )
 }
 
 const CalendarModals = ({
@@ -60,39 +164,22 @@ const CalendarModals = ({
       id: result.id ?? safeDetailEventId ?? 0,
     }
   }, [data, safeDetailEventId])
+  const resetKey = `${String(modalEventId ?? 'closed')}::${occurrenceDate}::${isModalEditing ? 'edit' : 'create'}`
+
   return (
     <>
       {/* ItemEditorModal 내부 포털을 그대로 사용해, 리사이즈 시 같은 폼 상태로 루트만 이동합니다. */}
-      {shouldRenderModal && isTodoModal && (
-        <TodoEditorModal
-          key={`todo-${String(modalEventId)}-${occurrenceDate}-${isModalEditing ? 'edit' : 'create'}`}
-          date={modalDate}
-          onClose={onCloseModal}
-          mode={modalMode}
-          eventId={modalEventId}
-          event={modalEvent}
-          showTypeTabs={!isModalEditing}
-          onEventColorChange={eventActions.onEventColorChange}
-          onEventTitleConfirm={eventActions.onEventTitleConfirm}
-          onEventTypeChange={eventActions.onEventTypeChange}
-          onEventTimingChange={eventActions.onEventTimingChange}
-          isEditing={isModalEditing}
-        />
-      )}
-      {shouldRenderModal && !isTodoModal && (
-        <ScheduleEditorModal
-          key={`schedule-${String(modalEventId)}-${occurrenceDate}-${isModalEditing ? 'edit' : 'create'}`}
-          date={modalDate}
-          onClose={onCloseModal}
-          mode={modalMode}
-          eventId={modalEventId}
-          event={detailEvent ?? modalEvent}
-          isEditing={isModalEditing}
-          showTypeTabs={!isModalEditing}
-          onEventColorChange={eventActions.onEventColorChange}
-          onEventTitleConfirm={eventActions.onEventTitleConfirm}
-          onEventTypeChange={eventActions.onEventTypeChange}
-          onEventTimingChange={eventActions.onEventTimingChange}
+      {shouldRenderModal && modalEventId != null && (
+        <DraftBackedModal
+          key={resetKey}
+          modalDate={modalDate}
+          modalEventId={modalEventId}
+          modalEvent={modalEvent}
+          detailEvent={detailEvent}
+          isModalEditing={isModalEditing}
+          modalMode={modalMode}
+          onCloseModal={onCloseModal}
+          eventActions={eventActions}
         />
       )}
     </>

--- a/src/features/Calendar/components/CustomCalendar/CalendarModals.tsx
+++ b/src/features/Calendar/components/CustomCalendar/CalendarModals.tsx
@@ -3,11 +3,10 @@ import { useMemo, useState } from 'react'
 
 import { useDetailEventQuery } from '@/shared/hooks/query/useCalendarQueries'
 import type { CalendarEvent } from '@/shared/types/calendar/types'
-import type { RepeatConfigSchema } from '@/shared/types/event/event'
 import type { ItemEditorDraft } from '@/shared/types/modal/itemEditor'
-import { defaultRepeatConfig } from '@/shared/types/recurrence/repeat'
 import ScheduleEditorModal from '@/shared/ui/Modals/ScheduleEditor'
 import TodoEditorModal from '@/shared/ui/Modals/TodoEditor'
+import { buildDefaultItemEditorDraft } from '@/shared/utils'
 
 type CalendarModalsProps = {
   modalDate: string
@@ -27,39 +26,6 @@ type CalendarModalsProps = {
       allDay: boolean,
       occurrenceDate?: CalendarEvent['occurrenceDate'],
     ) => void
-  }
-}
-
-const pad2 = (value: number) => String(value).padStart(2, '0')
-
-const formatTimeFromDate = (value: Date) => `${pad2(value.getHours())}:${pad2(value.getMinutes())}`
-
-const getDefaultDraft = (
-  date: string,
-  initialType: 'todo' | 'schedule',
-  initialEvent?: CalendarEvent | null,
-): ItemEditorDraft => {
-  const baseStart = initialEvent?.start ? new Date(initialEvent.start) : new Date(date)
-  const baseEnd =
-    initialEvent?.end && new Date(initialEvent.end).getTime() !== baseStart.getTime()
-      ? new Date(initialEvent.end)
-      : new Date(baseStart.getTime() + 60 * 60 * 1000)
-
-  return {
-    title:
-      initialType === 'schedule' && initialEvent?.title === '새 일정'
-        ? ''
-        : (initialEvent?.title ?? ''),
-    description: initialEvent?.content ?? '',
-    startDate: baseStart,
-    endDate: baseEnd,
-    startTime: formatTimeFromDate(baseStart),
-    endTime: initialType === 'todo' ? formatTimeFromDate(baseStart) : formatTimeFromDate(baseEnd),
-    isAllday: initialEvent?.isAllDay ?? false,
-    eventColor: initialEvent?.color ?? (initialType === 'todo' ? 'GRAY' : 'BLUE'),
-    repeatConfig: defaultRepeatConfig as RepeatConfigSchema,
-    location: initialEvent?.location ?? '',
-    address: initialEvent?.address ?? null,
   }
 }
 
@@ -84,12 +50,12 @@ const DraftBackedModal = ({
   onCloseModal,
   eventActions,
 }: DraftBackedModalProps) => {
-  const isTodoModal = modalEvent?.type === 'todo'
   const activeEvent = detailEvent ?? modalEvent
+  const isTodoModal = activeEvent?.type === 'todo'
   const [draftValues, setDraftValues] = useState<ItemEditorDraft | null>(() =>
     isModalEditing
       ? null
-      : getDefaultDraft(modalDate, isTodoModal ? 'todo' : 'schedule', activeEvent),
+      : buildDefaultItemEditorDraft(modalDate, isTodoModal ? 'todo' : 'schedule', activeEvent),
   )
 
   if (isTodoModal) {
@@ -99,7 +65,7 @@ const DraftBackedModal = ({
         onClose={onCloseModal}
         mode={modalMode}
         eventId={modalEventId}
-        event={modalEvent}
+        event={activeEvent}
         showTypeTabs={!isModalEditing}
         draftValues={draftValues}
         onDraftChange={setDraftValues}
@@ -118,7 +84,7 @@ const DraftBackedModal = ({
       onClose={onCloseModal}
       mode={modalMode}
       eventId={modalEventId}
-      event={detailEvent ?? modalEvent}
+      event={activeEvent}
       isEditing={isModalEditing}
       showTypeTabs={!isModalEditing}
       draftValues={draftValues}

--- a/src/features/Calendar/components/CustomEvent/CustomEvent.style.ts
+++ b/src/features/Calendar/components/CustomEvent/CustomEvent.style.ts
@@ -98,7 +98,7 @@ export const WeekEventContainer = styled.div<{
 export const EventTitle = styled.div`
   font-weight: 400;
   font-size: 12px;
-  width: 45px;
+  width: 38px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/shared/hooks/form/useScheduleFormFields.ts
+++ b/src/shared/hooks/form/useScheduleFormFields.ts
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { type Control, type Resolver, useForm, type UseFormReturn, useWatch } from 'react-hook-form'
 
 import { addScheduleSchema } from '@/shared/schemas/schedule'
@@ -113,6 +113,7 @@ export const useScheduleFormFields = ({
     () => buildScheduleDefaultValues({ date, initialEvent, draftValues }),
     [date, draftValues, initialEvent],
   )
+  const previousResetKeyRef = useRef(`${date}::${String(initialEvent?.id ?? 'new')}`)
   const formMethods = useForm<ScheduleEditorFormValues>({
     resolver,
     defaultValues: initialValues,
@@ -148,8 +149,11 @@ export const useScheduleFormFields = ({
 
   useEffect(() => {
     if (isEditing) return
+    const nextResetKey = `${date}::${String(initialEvent?.id ?? 'new')}`
+    if (previousResetKeyRef.current === nextResetKey) return
+    previousResetKeyRef.current = nextResetKey
     reset(initialValues)
-  }, [date, initialValues, isEditing, reset])
+  }, [date, initialEvent?.id, initialValues, isEditing, reset])
 
   useEffect(() => {
     if (isEditing || !onDraftChange) return

--- a/src/shared/hooks/form/useTodoFormFields.ts
+++ b/src/shared/hooks/form/useTodoFormFields.ts
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup'
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { type Control, type Resolver, useForm, type UseFormReturn, useWatch } from 'react-hook-form'
 
 import { addTodoSchema } from '@/shared/schemas/todo'
@@ -73,6 +73,7 @@ export const useTodoFormFields = ({
     () => buildTodoDefaultValues({ date, initialEvent, draftValues }),
     [date, draftValues, initialEvent],
   )
+  const previousResetKeyRef = useRef(`${date}::${String(initialEvent?.id ?? 'new')}`)
   const formMethods = useForm<TodoEditorFormValues>({
     resolver,
     defaultValues: initialValues,
@@ -98,8 +99,11 @@ export const useTodoFormFields = ({
 
   useEffect(() => {
     if (isEditing) return
+    const nextResetKey = `${date}::${String(initialEvent?.id ?? 'new')}`
+    if (previousResetKeyRef.current === nextResetKey) return
+    previousResetKeyRef.current = nextResetKey
     reset(initialValues)
-  }, [date, initialValues, isEditing, reset])
+  }, [date, initialEvent?.id, initialValues, isEditing, reset])
 
   useEffect(() => {
     if (isEditing || !onDraftChange) return

--- a/src/shared/ui/Modals/ItemEditorModal/index.tsx
+++ b/src/shared/ui/Modals/ItemEditorModal/index.tsx
@@ -17,6 +17,18 @@ const pad2 = (value: number) => String(value).padStart(2, '0')
 
 const formatTimeFromDate = (value: Date) => `${pad2(value.getHours())}:${pad2(value.getMinutes())}`
 
+const buildDateTime = (fallbackDate: string, dateValue?: Date | null, timeValue?: string) => {
+  const nextDate = dateValue ? new Date(dateValue) : new Date(fallbackDate)
+  if (!timeValue) {
+    nextDate.setHours(0, 0, 0, 0)
+    return nextDate
+  }
+
+  const [hour, minute] = timeValue.split(':').map((value) => Number.parseInt(value, 10))
+  nextDate.setHours(Number.isNaN(hour) ? 0 : hour, Number.isNaN(minute) ? 0 : minute, 0, 0)
+  return nextDate
+}
+
 const getDefaultDraft = (
   date: string,
   initialType: ItemType,
@@ -65,6 +77,8 @@ type ItemEditorModalProps = {
     allDay: boolean,
     occurrenceDate?: CalendarEvent['occurrenceDate'],
   ) => void
+  draftValues?: ItemEditorDraft | null
+  onDraftChange?: (draft: ItemEditorDraft | null) => void
 }
 
 const ItemEditorModal = ({
@@ -80,16 +94,30 @@ const ItemEditorModal = ({
   onEventTitleConfirm,
   onEventTypeChange,
   onEventTimingChange,
+  draftValues: externalDraftValues,
+  onDraftChange: onExternalDraftChange,
 }: ItemEditorModalProps) => {
   const [activeType, setActiveType] = useState<ItemType>(initialType)
-  const [draftValues, setDraftValues] = useState<ItemEditorDraft | null>(() =>
+  const [internalDraftValues, setInternalDraftValues] = useState<ItemEditorDraft | null>(() =>
     isEditing ? null : getDefaultDraft(date, initialType, initialEvent),
+  )
+  const draftValues = externalDraftValues ?? internalDraftValues
+  const setDraftValues = useCallback(
+    (draft: ItemEditorDraft | null) => {
+      if (onExternalDraftChange) {
+        onExternalDraftChange(draft)
+        return
+      }
+      setInternalDraftValues(draft)
+    },
+    [onExternalDraftChange],
   )
   const [footerChildren, setFooterChildren] = useState<ReactNode | null>(null)
   const [deleteHandler, setDeleteHandler] = useState<() => void>(() => () => undefined)
   const [closeGuard, setCloseGuard] = useState<null | (() => boolean)>(null)
   const [modalWrapperElement, setModalWrapperElement] = useState<HTMLDivElement | null>(null)
   const modalWrapperRef = useRef<HTMLDivElement | null>(null)
+  const previousActiveTypeRef = useRef(activeType)
   const noopDeleteHandler = useCallback(() => undefined, [])
 
   const registerDeleteHandler = useCallback(
@@ -120,13 +148,68 @@ const ItemEditorModal = ({
   }, [initialType])
 
   useEffect(() => {
-    setDraftValues(isEditing ? null : getDefaultDraft(date, initialType, initialEvent))
-  }, [date, initialEvent, initialType, isEditing])
+    if (externalDraftValues !== undefined) return
+    setInternalDraftValues(isEditing ? null : getDefaultDraft(date, initialType, initialEvent))
+  }, [date, externalDraftValues, initialEvent, initialType, isEditing])
 
   useEffect(() => {
     if (eventId == null || eventId === 0) return
     onEventTypeChange?.(eventId, activeType)
   }, [activeType, eventId, onEventTypeChange])
+
+  useEffect(() => {
+    if (!showTypeTabs) return
+    if (previousActiveTypeRef.current === activeType) return
+    previousActiveTypeRef.current = activeType
+    if (eventId == null || eventId === 0) return
+    if (!onEventTimingChange) return
+
+    const startDate =
+      draftValues?.startDate ?? (initialEvent?.start ? new Date(initialEvent.start) : null)
+    const endDate =
+      draftValues?.endDate ?? (initialEvent?.end ? new Date(initialEvent.end) : startDate)
+    const isAllDay = draftValues?.isAllday ?? initialEvent?.isAllDay ?? false
+    const occurrenceDate = initialEvent?.occurrenceDate
+
+    if (activeType === 'todo') {
+      if (isAllDay) {
+        const start = new Date(startDate ?? new Date(date))
+        start.setHours(0, 0, 0, 0)
+        const end = new Date(start)
+        end.setHours(23, 59, 59, 999)
+        onEventTimingChange(eventId, start, end, true, occurrenceDate)
+        return
+      }
+
+      const point = buildDateTime(date, startDate, draftValues?.endTime ?? draftValues?.startTime)
+      onEventTimingChange(eventId, point, point, false, occurrenceDate)
+      return
+    }
+
+    if (isAllDay) {
+      const start = new Date(startDate ?? new Date(date))
+      start.setHours(0, 0, 0, 0)
+      const end = new Date(endDate ?? start)
+      end.setHours(23, 59, 59, 999)
+      onEventTimingChange(eventId, start, end, true, occurrenceDate)
+      return
+    }
+
+    const start = buildDateTime(date, startDate, draftValues?.startTime)
+    const end = buildDateTime(date, endDate ?? startDate, draftValues?.endTime)
+    onEventTimingChange(eventId, start, end, false, occurrenceDate)
+  }, [
+    activeType,
+    date,
+    draftValues,
+    eventId,
+    initialEvent?.end,
+    initialEvent?.isAllDay,
+    initialEvent?.occurrenceDate,
+    initialEvent?.start,
+    onEventTimingChange,
+    showTypeTabs,
+  ])
 
   const handleSubmit = useCallback(() => {
     const submitFormId = activeType === 'todo' ? 'add-todo-form' : 'add-schedule-form'

--- a/src/shared/ui/Modals/ItemEditorModal/index.tsx
+++ b/src/shared/ui/Modals/ItemEditorModal/index.tsx
@@ -2,20 +2,15 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import { createPortal } from 'react-dom'
 
 import type { CalendarEvent } from '@/shared/types/calendar/types'
-import type { RepeatConfigSchema } from '@/shared/types/event/event'
 import type { ItemEditorDraft } from '@/shared/types/modal/itemEditor'
-import { defaultRepeatConfig } from '@/shared/types/recurrence/repeat'
 import ScheduleEditorForm from '@/shared/ui/Modals/ScheduleEditor/ScheduleEditorForm'
 import TodoEditorForm from '@/shared/ui/Modals/TodoEditor/TodoEditorForm'
+import { buildDefaultItemEditorDraft } from '@/shared/utils'
 
 import EditorModalLayout from './EditorModalLayout'
 import * as S from './ItemEditorModal.style'
 
 type ItemType = 'todo' | 'schedule'
-
-const pad2 = (value: number) => String(value).padStart(2, '0')
-
-const formatTimeFromDate = (value: Date) => `${pad2(value.getHours())}:${pad2(value.getMinutes())}`
 
 const buildDateTime = (fallbackDate: string, dateValue?: Date | null, timeValue?: string) => {
   const nextDate = dateValue ? new Date(dateValue) : new Date(fallbackDate)
@@ -27,35 +22,6 @@ const buildDateTime = (fallbackDate: string, dateValue?: Date | null, timeValue?
   const [hour, minute] = timeValue.split(':').map((value) => Number.parseInt(value, 10))
   nextDate.setHours(Number.isNaN(hour) ? 0 : hour, Number.isNaN(minute) ? 0 : minute, 0, 0)
   return nextDate
-}
-
-const getDefaultDraft = (
-  date: string,
-  initialType: ItemType,
-  initialEvent?: CalendarEvent | null,
-): ItemEditorDraft => {
-  const baseStart = initialEvent?.start ? new Date(initialEvent.start) : new Date(date)
-  const baseEnd =
-    initialEvent?.end && new Date(initialEvent.end).getTime() !== baseStart.getTime()
-      ? new Date(initialEvent.end)
-      : new Date(baseStart.getTime() + 60 * 60 * 1000)
-
-  return {
-    title:
-      initialType === 'schedule' && initialEvent?.title === '새 일정'
-        ? ''
-        : (initialEvent?.title ?? ''),
-    description: initialEvent?.content ?? '',
-    startDate: baseStart,
-    endDate: baseEnd,
-    startTime: formatTimeFromDate(baseStart),
-    endTime: initialType === 'todo' ? formatTimeFromDate(baseStart) : formatTimeFromDate(baseEnd),
-    isAllday: initialEvent?.isAllDay ?? false,
-    eventColor: initialEvent?.color ?? (initialType === 'todo' ? 'GRAY' : 'BLUE'),
-    repeatConfig: defaultRepeatConfig as RepeatConfigSchema,
-    location: initialEvent?.location ?? '',
-    address: initialEvent?.address ?? null,
-  }
 }
 
 type ItemEditorModalProps = {
@@ -99,9 +65,10 @@ const ItemEditorModal = ({
 }: ItemEditorModalProps) => {
   const [activeType, setActiveType] = useState<ItemType>(initialType)
   const [internalDraftValues, setInternalDraftValues] = useState<ItemEditorDraft | null>(() =>
-    isEditing ? null : getDefaultDraft(date, initialType, initialEvent),
+    isEditing ? null : buildDefaultItemEditorDraft(date, initialType, initialEvent),
   )
   const draftValues = externalDraftValues ?? internalDraftValues
+  const draftValuesRef = useRef(draftValues)
   const setDraftValues = useCallback(
     (draft: ItemEditorDraft | null) => {
       if (onExternalDraftChange) {
@@ -119,6 +86,10 @@ const ItemEditorModal = ({
   const modalWrapperRef = useRef<HTMLDivElement | null>(null)
   const previousActiveTypeRef = useRef(activeType)
   const noopDeleteHandler = useCallback(() => undefined, [])
+
+  useEffect(() => {
+    draftValuesRef.current = draftValues
+  }, [draftValues])
 
   const registerDeleteHandler = useCallback(
     (handler?: (() => void) | null) => {
@@ -149,7 +120,9 @@ const ItemEditorModal = ({
 
   useEffect(() => {
     if (externalDraftValues !== undefined) return
-    setInternalDraftValues(isEditing ? null : getDefaultDraft(date, initialType, initialEvent))
+    setInternalDraftValues(
+      isEditing ? null : buildDefaultItemEditorDraft(date, initialType, initialEvent),
+    )
   }, [date, externalDraftValues, initialEvent, initialType, isEditing])
 
   useEffect(() => {
@@ -164,11 +137,12 @@ const ItemEditorModal = ({
     if (eventId == null || eventId === 0) return
     if (!onEventTimingChange) return
 
+    const latestDraftValues = draftValuesRef.current
     const startDate =
-      draftValues?.startDate ?? (initialEvent?.start ? new Date(initialEvent.start) : null)
+      latestDraftValues?.startDate ?? (initialEvent?.start ? new Date(initialEvent.start) : null)
     const endDate =
-      draftValues?.endDate ?? (initialEvent?.end ? new Date(initialEvent.end) : startDate)
-    const isAllDay = draftValues?.isAllday ?? initialEvent?.isAllDay ?? false
+      latestDraftValues?.endDate ?? (initialEvent?.end ? new Date(initialEvent.end) : startDate)
+    const isAllDay = latestDraftValues?.isAllday ?? initialEvent?.isAllDay ?? false
     const occurrenceDate = initialEvent?.occurrenceDate
 
     if (activeType === 'todo') {
@@ -181,7 +155,11 @@ const ItemEditorModal = ({
         return
       }
 
-      const point = buildDateTime(date, startDate, draftValues?.endTime ?? draftValues?.startTime)
+      const point = buildDateTime(
+        date,
+        startDate,
+        latestDraftValues?.endTime ?? latestDraftValues?.startTime,
+      )
       onEventTimingChange(eventId, point, point, false, occurrenceDate)
       return
     }
@@ -195,13 +173,12 @@ const ItemEditorModal = ({
       return
     }
 
-    const start = buildDateTime(date, startDate, draftValues?.startTime)
-    const end = buildDateTime(date, endDate ?? startDate, draftValues?.endTime)
+    const start = buildDateTime(date, startDate, latestDraftValues?.startTime)
+    const end = buildDateTime(date, endDate ?? startDate, latestDraftValues?.endTime)
     onEventTimingChange(eventId, start, end, false, occurrenceDate)
   }, [
     activeType,
     date,
-    draftValues,
     eventId,
     initialEvent?.end,
     initialEvent?.isAllDay,

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './date'
 export * from './error'
 export * from './formError'
+export * from './itemEditorDraft'
 export * from './priority'
 export * from './recurrenceGroup'
 export * from './repeatConfig'

--- a/src/shared/utils/itemEditorDraft.ts
+++ b/src/shared/utils/itemEditorDraft.ts
@@ -1,0 +1,37 @@
+import type { CalendarEvent } from '@/shared/types/calendar/types'
+import type { RepeatConfigSchema } from '@/shared/types/event/event'
+import type { ItemEditorDraft } from '@/shared/types/modal/itemEditor'
+import { defaultRepeatConfig } from '@/shared/types/recurrence/repeat'
+
+const pad2 = (value: number) => String(value).padStart(2, '0')
+
+const formatTimeFromDate = (value: Date) => `${pad2(value.getHours())}:${pad2(value.getMinutes())}`
+
+export const buildDefaultItemEditorDraft = (
+  date: string,
+  initialType: 'todo' | 'schedule',
+  initialEvent?: CalendarEvent | null,
+): ItemEditorDraft => {
+  const baseStart = initialEvent?.start ? new Date(initialEvent.start) : new Date(date)
+  const baseEnd =
+    initialEvent?.end && new Date(initialEvent.end).getTime() !== baseStart.getTime()
+      ? new Date(initialEvent.end)
+      : new Date(baseStart.getTime() + 60 * 60 * 1000)
+
+  return {
+    title:
+      initialType === 'schedule' && initialEvent?.title === '새 일정'
+        ? ''
+        : (initialEvent?.title ?? ''),
+    description: initialEvent?.content ?? '',
+    startDate: baseStart,
+    endDate: baseEnd,
+    startTime: formatTimeFromDate(baseStart),
+    endTime: initialType === 'todo' ? formatTimeFromDate(baseStart) : formatTimeFromDate(baseEnd),
+    isAllday: initialEvent?.isAllDay ?? false,
+    eventColor: initialEvent?.color ?? (initialType === 'todo' ? 'GRAY' : 'BLUE'),
+    repeatConfig: defaultRepeatConfig as RepeatConfigSchema,
+    location: initialEvent?.location ?? '',
+    address: initialEvent?.address ?? null,
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #92

---

## 🧩 작업 요약 (TL;DR)

> 이 PR에서 **무엇을 왜** 했는지 한 줄로 요약해주세요.

- 일정/할일 생성 모달에서 한글 입력이 깨지던 문제를 수정하고, 일정 ↔ 할일 전환 시 메모와 미리보기 시간이 올바르게 유지되도록 개선

---

## 🔄 변경 유형

해당되는 항목에 체크해주세요.

- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] 🔨 Refactor 
- [ ] 🎨 UI / UX
- [ ] ⚙️ Setting / Infra
- [ ] 🧪 Test
- [ ] 📄 Docs

---

## 📌 주요 변경 사항

> 리뷰어가 **집중해서 봐야 할 포인트**

- 생성 모달에서 draft 상태를 다루는 방식을 조정해, 입력 중 `reset()`이 반복되며 한글 조합형 입력이 깨지던 문제를 수정했습니다.
- 일정 ↔ 할일 전환 시 draft 상태를 공통으로 유지하도록 변경해 메모가 사라지지 않도록 했습니다.
- 1일 이상 일정에서 할일로 전환할 때, 일정 범위 미리보기가 남지 않고 할일 기준 단일 시점으로 즉시 동기화되도록 수정했습니다.


## 🖼️ 스크린샷 / 영상 (선택)

X

---

## 🧠 리뷰 요청 포인트

> 리뷰어에게 **특히 봐줬으면 하는 부분**

- [ ] 로직 설계
- [x] 상태 관리 방식
- [ ] 네이밍
- [x] 성능 / 렌더링
- [ ] 기타: **일정/할일 전환 시 draft 및 preview 동기화 흐름**

---

## ⚠️ 체크리스트 (PR 올리기 전)

- [ ] 로컬에서 정상 동작 확인
- [ ] 기존 기능에 영향 없음
- [x] 불필요한 console.log 제거
- [x] 린트 / 타입 에러 없음
- [x] 관련 이슈 연결 완료

---

## 🚧 미완 / 후속 작업

> 이 PR에서 다루지 않은 내용이나 추후 작업

---

## 💬 기타 참고 사항

> 리뷰어가 알면 좋은 맥락, 트레이드오프, 고민 지점

- 모달 전환 시 컴포넌트 재마운트가 발생하더라도 draft가 유지되도록 상태 소유 위치를 조정.
- 입력 버그 수정 과정에서 생성 모달의 초기화 시점을 제한해 IME 조합 입력이 중간에 끊기지 않도록 했습니다.

@copilot 이 PR을 아래 기준으로 검토해주세요:

.github/instructions/capstone.instructions.md 파일을 지침으로 삼으세요.
폴더/파일 위치가 프로젝트 구조 규칙과 일치하는지
컴포넌트가 단일 책임 원칙(SRP)을 지키는지
import 방향이 올바른지 (shared → features 역방향 없음)
명명/케이스가 일관적인지 (PascalCase vs camelCase)
배럴(index.ts) 사용이 현 패턴을 따르는지
응답은 한국어로, 발견된 위반 항목과 추천 구조를 포함해주세요.
리뷰를 달아주세요
