### PR TITLE
[BugFix] max-width 추가

### DIFF
--- a/src/features/Calendar/components/CustomEvent/CustomEvent.style.ts
+++ b/src/features/Calendar/components/CustomEvent/CustomEvent.style.ts
@@ -107,6 +107,7 @@ export const EventTitle = styled.div`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 80px;
 `
 
 export const EventMeta = styled.div`


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #111
- 참고: #111

---

## 🧩 작업 요약 (TL;DR)

- 일정 수정 미리보기에서 긴 일정 제목이 카드 너비를 늘리지 않도록 말줄임 처리 및 이벤트 래퍼 폭 제약을 보강했습니다.

---

## 🔄 변경 유형

- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] 🔨 Refactor (기능 변화 없음)
- [x] 🎨 UI / UX
- [ ] ⚙️ Setting / Infra
- [ ] 🧪 Test
- [ ] 📄 Docs

---

## 📌 주요 변경 사항

> 리뷰어가 **집중해서 봐야 할 포인트**

- 일정 제목이 길어질 때 이벤트 카드 자체가 늘어나던 문제를 방지하기 위해 `min-width: 0`, `max-width: 100%`, `overflow: hidden` 스타일을 보강했습니다.
- 월/주/일 뷰의 이벤트 카드 및 `react-big-calendar` 이벤트 래퍼에 동일한 폭 제약을 적용했습니다.
- 일간 뷰의 종일 일정 제목이 말줄임 스타일을 타도록 텍스트 직접 렌더링 대신 `EventTitle` 컴포넌트로 감쌌습니다.

---

## 🖼️ 스크린샷 / 영상 (선택)

> UI 변경이 있다면 꼭 첨부해주세요.

| Before | After |
| ------ | ----- |
| <img width="1440" height="735" alt="스크린샷 2026-06-02 오후 2 18 07" src="https://github.com/user-attachments/assets/fadf32a0-77e2-4e29-9153-fdef09d0b2d8" /> | <img width="1440" height="735" alt="스크린샷 2026-06-02 오후 2 17 59" src="https://github.com/user-attachments/assets/d2da551d-b059-4cf5-bf4f-f8d38d1025ed" /> |



---

## 🧠 리뷰 요청 포인트

> 리뷰어에게 **특히 봐줬으면 하는 부분**

- [ ] 로직 설계
- [ ] 상태 관리 방식
- [ ] 네이밍
- [x] 성능 / 렌더링
- [x] 기타: **월/주/일 캘린더 뷰에서 이벤트 카드 폭 제약이 일관적으로 적용되는지**

---

## ⚠️ 체크리스트 (PR 올리기 전)

- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 불필요한 console.log 제거
- [x] 린트 / 타입 에러 없음
- [x] 관련 이슈 연결 완료

---

## 🚧 미완 / 후속 작업

> 이 PR에서 다루지 않은 내용이나 추후 작업

- N/A

---

## 💬 기타 참고 사항

> 리뷰어가 알면 좋은 맥락, 트레이드오프, 고민 지점

@copilot 이 PR을 아래 기준으로 검토해주세요:

.github/instructions/capstone.instructions.md 파일을 지침으로 삼으세요.
폴더/파일 위치가 프로젝트 구조 규칙과 일치하는지
컴포넌트가 단일 책임 원칙(SRP)을 지키는지
import 방향이 올바른지 (shared → features 역방향 없음)
명명/케이스가 일관적인지 (PascalCase vs camelCase)
배럴(index.ts) 사용이 현 패턴을 따르는지
응답은 한국어로, 발견된 위반 항목과 추천 구조를 포함해주세요.
리뷰를 달아주세요