### PR TITLE
[Bugfix] 임시 일정/할 일 삭제 시 서버 요청 방지

### DIFF
--- a/src/features/Calendar/components/EventDetailCard/EventDetailCard.style.ts
+++ b/src/features/Calendar/components/EventDetailCard/EventDetailCard.style.ts
@@ -43,6 +43,7 @@ export const Content = styled.div`
 export const TextWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
 `
 

--- a/src/features/Calendar/hooks/useCalendarDraftEvent.ts
+++ b/src/features/Calendar/hooks/useCalendarDraftEvent.ts
@@ -32,11 +32,16 @@ export const useCalendarDraftEvent = ({
   updateEventTiming,
 }: UseCalendarDraftEventArgs) => {
   const handleCloseModalWithCleanup = useCallback(() => {
-    if (!isModalEditing && modal.eventId != null) {
-      removeEvent(modal.eventId)
+    if (modal.eventId != null) {
+      const shouldRemoveDraft =
+        !isModalEditing ||
+        events.some((eventItem) => eventItem.id === modal.eventId && eventItem.isTemporary)
+      if (shouldRemoveDraft) {
+        removeEvent(modal.eventId)
+      }
     }
     handleCloseModal()
-  }, [handleCloseModal, isModalEditing, modal.eventId, removeEvent])
+  }, [events, handleCloseModal, isModalEditing, modal.eventId, removeEvent])
 
   const clearPendingDraftEvent = useCallback(() => {
     if (!modal.isOpen || isModalEditing || modal.eventId == null) return

--- a/src/features/Calendar/hooks/useCalendarEvents.ts
+++ b/src/features/Calendar/hooks/useCalendarEvents.ts
@@ -144,7 +144,9 @@ export const useCalendarEvents = (options: UseCalendarEventsOptions = {}) => {
   // 서버 응답 후 임시 이벤트 id를 실제 id로 교체
   const updateEventId = useCallback((tempId: CalendarEvent['id'], nextId: CalendarEvent['id']) => {
     setEvents((prev) =>
-      prev.map((event) => (event.id === tempId ? { ...event, id: nextId } : event)),
+      prev.map((event) =>
+        event.id === tempId ? { ...event, id: nextId, isTemporary: false } : event,
+      ),
     )
   }, [])
 

--- a/src/features/Calendar/utils/helpers/calendarPageHelpers.ts
+++ b/src/features/Calendar/utils/helpers/calendarPageHelpers.ts
@@ -34,6 +34,7 @@ export const createEvent = (date: Date, index: number, allDay = false): Calendar
     recurrenceGroup: null,
     friendIds: [],
     type: 'schedule',
+    isTemporary: true,
   }
 }
 

--- a/src/features/Todo/components/TodoCard/TodoCard.style.ts
+++ b/src/features/Todo/components/TodoCard/TodoCard.style.ts
@@ -45,6 +45,15 @@ export const ButtonWrapper = styled.div`
     }
   }
 `
+export const DeleteButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+`
 export const TodoLeftWrapper = styled.div`
   display: flex;
   gap: 16px;

--- a/src/features/Todo/components/TodoCard/TodoCard.tsx
+++ b/src/features/Todo/components/TodoCard/TodoCard.tsx
@@ -86,14 +86,16 @@ const TodoCard = ({
       </S.TodoLeftWrapper>
       <S.ButtonWrapper>
         <PriorityBadge priority={priority} />
-        <Trash
-          color="#c5c5c5"
+        <S.DeleteButton
+          type="button"
+          aria-label={`${title} 삭제`}
           onClick={(event) => {
             event.stopPropagation()
             handleDelete()
           }}
-          style={{ cursor: 'pointer' }}
-        />
+        >
+          <Trash color="#c5c5c5" />
+        </S.DeleteButton>
       </S.ButtonWrapper>
       {openDeleteModal && isRecurringTodo && (
         <DeleteConfirmModal

--- a/src/features/Todo/components/TodoCard/TodoCard.tsx
+++ b/src/features/Todo/components/TodoCard/TodoCard.tsx
@@ -92,6 +92,7 @@ const TodoCard = ({
             event.stopPropagation()
             handleDelete()
           }}
+          style={{ cursor: 'pointer' }}
         />
       </S.ButtonWrapper>
       {openDeleteModal && isRecurringTodo && (

--- a/src/shared/hooks/addSchedule/useScheduleFooter.tsx
+++ b/src/shared/hooks/addSchedule/useScheduleFooter.tsx
@@ -58,6 +58,7 @@ export const useScheduleFooter = ({
   const occurrenceDateRef = useRef(occurrenceDate)
   const closeModalRef = useRef(closeModal)
   const deleteEventMutateRef = useRef(deleteEventMutate)
+  const isTemporaryEventRef = useRef(Boolean(initialEvent?.isTemporary))
   const canEditRef = useRef(canEdit)
   const onReadOnlyAttemptRef = useRef(onReadOnlyAttempt)
   const eventColorRef = useRef(eventColor)
@@ -72,6 +73,7 @@ export const useScheduleFooter = ({
   occurrenceDateRef.current = occurrenceDate
   closeModalRef.current = closeModal
   deleteEventMutateRef.current = deleteEventMutate
+  isTemporaryEventRef.current = Boolean(initialEvent?.isTemporary)
   canEditRef.current = canEdit
   onReadOnlyAttemptRef.current = onReadOnlyAttempt
   eventColorRef.current = eventColor
@@ -84,6 +86,11 @@ export const useScheduleFooter = ({
   const handleDelete = useCallback(() => {
     if (!canEditRef.current) {
       onReadOnlyAttemptRef.current?.()
+      return
+    }
+    if (eventIdRef.current == null || eventIdRef.current === 0 || isTemporaryEventRef.current) {
+      setDeleteWarningVisible(false)
+      closeModalRef.current()
       return
     }
     if (repeatConfigRef.current.repeatType !== 'none') {
@@ -130,7 +137,7 @@ export const useScheduleFooter = ({
     if (currentEventId != null && currentEventId !== 0) {
       onEventColorChangeRef.current?.(currentEventId, value)
     }
-    if (!isEditingRef.current) {
+    if (!isEditingRef.current || isTemporaryEventRef.current) {
       return
     }
     const nextValues = { ...getValuesRef.current(), eventColor: value }

--- a/src/shared/hooks/addSchedule/useSchedulePatch.ts
+++ b/src/shared/hooks/addSchedule/useSchedulePatch.ts
@@ -80,7 +80,7 @@ export const useSchedulePatch = ({
 }: UseSchedulePatchArgs) =>
   useCallback(
     (values: ScheduleEditorFormValues, scope?: RecurrenceEventScope, occurrenceDate?: string) => {
-      if (eventId == null || eventId === 0) return Promise.resolve()
+      if (eventId == null || eventId === 0 || initialEvent?.isTemporary) return Promise.resolve()
       const startDate = values.eventStartDate ?? new Date(date)
       const endDate = values.eventEndDate ?? startDate
       const [start, end] = values.isAllday

--- a/src/shared/hooks/addSchedule/useScheduleSubmitFlow.ts
+++ b/src/shared/hooks/addSchedule/useScheduleSubmitFlow.ts
@@ -81,6 +81,7 @@ export const useScheduleSubmitFlow = ({
   }, [])
 
   const showToast = useToastStore.getState().showToast
+  const isTemporaryEvent = Boolean(initialEvent?.isTemporary)
 
   const confirmTitle = useCallback(
     (values: ScheduleEditorFormValues) => {
@@ -163,7 +164,7 @@ export const useScheduleSubmitFlow = ({
         return
       }
       await submitScheduleValues(values, {
-        mode: isEditing ? 'patch' : 'create',
+        mode: isEditing && !isTemporaryEvent ? 'patch' : 'create',
       })
     },
     (errors) => {

--- a/src/shared/hooks/addTodo/useTodoDetailHydration.ts
+++ b/src/shared/hooks/addTodo/useTodoDetailHydration.ts
@@ -12,6 +12,7 @@ type UseTodoDetailHydrationProps = {
   date: string
   eventId: CalendarEvent['id']
   isEditing: boolean
+  initialEvent?: CalendarEvent | null
   todoDate: Date | null
   setValue: UseFormSetValue<TodoEditorFormValues>
 }
@@ -20,11 +21,13 @@ export const useTodoDetailHydration = ({
   date,
   eventId,
   isEditing,
+  initialEvent,
   todoDate,
   setValue,
 }: UseTodoDetailHydrationProps) => {
   const hydratedDetailKeyRef = useRef<string | null>(null)
-  const isPersistedTodo = isEditing && eventId != null && eventId !== 0
+  const isPersistedTodo =
+    isEditing && eventId != null && eventId !== 0 && !initialEvent?.isTemporary
   const shouldFetchDetail = isPersistedTodo
   const detailOccurrenceDate = moment(date).format('YYYY-MM-DD')
   const { data: detailData } = useGetDetailTodoQuery(

--- a/src/shared/hooks/addTodo/useTodoFooter.tsx
+++ b/src/shared/hooks/addTodo/useTodoFooter.tsx
@@ -99,7 +99,12 @@ export const useTodoFooter = ({
     if (eventIdRef.current != null && eventIdRef.current !== 0) {
       onEventColorChangeRef.current?.(eventIdRef.current, value)
     }
-    if (!isEditingRef.current || eventIdRef.current == null || eventIdRef.current === 0) {
+    if (
+      !isEditingRef.current ||
+      eventIdRef.current == null ||
+      eventIdRef.current === 0 ||
+      !isPersistedTodoRef.current
+    ) {
       return
     }
     patchTodoMutateRef.current(

--- a/src/shared/hooks/form/useTodoEditorForm.ts
+++ b/src/shared/hooks/form/useTodoEditorForm.ts
@@ -127,7 +127,7 @@ export const useTodoEditorForm = ({
       recurrenceGroup,
     }
 
-    const isPersistedTodoId = typeof id === 'number' && id > 0
+    const isPersistedTodoId = typeof id === 'number' && id > 0 && !initialEvent?.isTemporary
     if (isEditing && isPersistedTodoId) {
       const occurrenceDate = options?.occurrenceDate ?? formatIsoDate(date)
       return patchTodoMutate({

--- a/src/shared/types/calendar/types.ts
+++ b/src/shared/types/calendar/types.ts
@@ -31,6 +31,7 @@ export type CalendarEvent = Omit<Event, 'start' | 'end'> & {
   type?: 'todo' | 'schedule'
   isDone?: boolean
   isRecurring?: boolean
+  isTemporary?: boolean
 }
 
 export type GetEventsResponseDTO = {

--- a/src/shared/ui/Modals/TodoEditor/TodoEditorContent.tsx
+++ b/src/shared/ui/Modals/TodoEditor/TodoEditorContent.tsx
@@ -39,6 +39,7 @@ const TodoEditorContent = ({
       date,
       eventId,
       isEditing,
+      initialEvent,
       todoDate: todo.todoDate,
       setValue,
     })


### PR DESCRIPTION
## 🔗 관련 이슈

- closes #120
- closes #124 
- closes #125 

---

## 🧩 작업 요약 (TL;DR)

> 이 PR에서 **무엇을 왜** 했는지 한 줄로 요약해주세요.

- 일정/할 일 임시 데이터 삭제 시 서버 요청을 막고, #120 관련 카드 UI 정렬 및 커서 스타일을 보완했습니다.

---

## 🔄 변경 유형

해당되는 항목에 체크해주세요.

- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] 🔨 Refactor (기능 변화 없음)
- [x] 🎨 UI / UX
- [ ] ⚙️ Setting / Infra
- [ ] 🧪 Test
- [ ] 📄 Docs

---

## 📌 주요 변경 사항

> 리뷰어가 **집중해서 봐야 할 포인트**

- `CalendarEvent`에 `isTemporary` 플래그를 추가해 서버 반영 전 로컬 임시 데이터와 서버 데이터를 구분했습니다.
- 임시 일정/할 일 삭제 시 delete API 요청 없이 로컬 데이터 제거 및 모달 닫기만 수행하도록 처리했습니다.
- 임시 항목에서 상세 조회, patch, 색상 변경 patch가 서버로 나가지 않도록 방어 조건을 추가했습니다.
- 임시 항목을 다시 열고 저장하는 경우 수정 요청이 아닌 생성 요청 흐름을 타도록 보완했습니다.
- 일정 상세 카드 텍스트 정렬을 `flex-start`로 맞췄습니다.
- 투두 카드 삭제 아이콘 hover 시 pointer 커서가 보이도록 스타일을 추가했습니다.

---

## 🖼️ 스크린샷 / 영상 (선택)

> UI 변경이 있다면 꼭 첨부해주세요.

| Before | After |
| ------ | ----- |
|        |       |

---

## 🧠 리뷰 요청 포인트

> 리뷰어에게 **특히 봐줬으면 하는 부분**

- [x] 로직 설계
- [x] 상태 관리 방식
- [x] 네이밍
- [ ] 성능 / 렌더링
- [x] 기타: **`isTemporary` 기준으로 서버 데이터와 로컬 임시 데이터를 분기하는 방식이 적절한지 확인 부탁드립니다.**

---

## ⚠️ 체크리스트 (PR 올리기 전)

- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음
- [x] 불필요한 console.log 제거
- [x] 린트 / 타입 에러 없음
- [x] 관련 이슈 연결 완료

---

## 🚧 미완 / 후속 작업

> 이 PR에서 다루지 않은 내용이나 추후 작업

- N/A

---

## 💬 기타 참고 사항

> 리뷰어가 알면 좋은 맥락, 트레이드오프, 고민 지점

- 기존 임시 이벤트 ID가 `Date.now()` 기반 양수라서 `id > 0` 조건만으로는 서버 저장 여부를 판단하기 어려웠습니다.
- 이를 해결하기 위해 `isTemporary` 플래그를 추가해 로컬 전용 항목을 명시적으로 구분했습니다.
- 삭제 흐름뿐 아니라 상세 조회, 수정, 색상 변경 patch에서도 임시 항목이 서버 요청을 발생시키지 않도록 함께 방어했습니다.
- `npm run build` 통과 확인했습니다.

@copilot 이 PR을 아래 기준으로 검토해주세요:

.github/instructions/capstone.instructions.md 파일을 지침으로 삼으세요.  
폴더/파일 위치가 프로젝트 구조 규칙과 일치하는지  
컴포넌트가 단일 책임 원칙(SRP)을 지키는지  
import 방향이 올바른지 (shared → features 역방향